### PR TITLE
Make keyword configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# alfred-almanac 
+# alfred-almanac
 
 ### Start your day with weather from [wttr.in](http://wttr.in/) and a daily almanac
 
@@ -31,31 +31,21 @@ src="https://img.shields.io/github/downloads/giovannicoppola/alfred-almanac/tota
 - Python3 (howto install [here](https://www.freecodecamp.org/news/python-version-on-mac-update/))
 
 ### Setup
-  
+
 1. Download the most recent release of `alfred-almanac` from Github and double-click to install
-2. In Alfred, open the 'Prepare workflow configuration and variables' window in `alfred-almanac` preferences
-	<img src='images/alfred5_prefs.png' width="500">
-			
-	- in the 'User Configuration' tab, set the 'Default Value' for the `LOCATION` variable to indicate the default locations as comma-separated city/town names, ZIP codes etc. 
-	- _Optional:_ in the 'User Configuration' tab, edit the 'Default Value' for the `FORMATSTRING` variable to customize the oneliner from `wttr.in`. Options and instructions available at the `wttr.in` [github page](https://github.com/chubin/wttr.in#one-line-output). 
-	- _Optional:_ in the 'User Configuration' tab, set the 'Default Value' for the `SPECIAL_DAY` variable (in the mm-dd format) to count days from and toward a special date. Default: `03-14` 
-	
+2. _Optional:_ Click `Configure Workflow` in `alfred-almanac` preferences to change settings
 3. _Optional:_ Setup a hotkey to launch alfred-almanac
-4. _Optional:_ Change the keyword to launch alfred-almanac
-	- keyword currently set to `!w`
-
-
 
 <a name="usage"></a>
-# Basic Usage 
+# Basic Usage
 ![](images/complice-almanac.png)
 
-- Launch `alfred-almanac` to retrieve weather and other almanac information from default locations ... 
+- Launch `alfred-almanac` to retrieve weather and other almanac information from default locations ...
 - ... or enter a location/ZIP code directly
 
 - The default weather string from `wttr.in` will output:
 	- `%C` weather condition text
-	- `%c` weather condition 
+	- `%c` weather condition
 	- 🌡️`%t` actual temperature
 	- `%f`  'feels like' temperature
 	- `%h` humidity
@@ -70,18 +60,18 @@ src="https://img.shields.io/github/downloads/giovannicoppola/alfred-almanac/tota
 	- days from and to the special day
 
 - Enter (↩️) will copy to the clipboard and past to the frontmost application
-- Shift-enter (⇧↩️) will open the corresponding page on `wttr.in` 
+- Shift-enter (⇧↩️) will open the corresponding page on `wttr.in`
 - CTRL-enter (⌃↩️) will show the almanac string in large font
 
 
 <a name="known-issues"></a>
-# Known issues 
+# Known issues
 - Not tested extensively for international locations
 
 <a name="acknowledgments"></a>
 # Acknowledgments
 - [Igor Chubin](https://twitter.com/igor_chubin) for developing the amazing `wttr.in`
-- The [Alfred forum](https://www.alfredforum.com) community. 
+- The [Alfred forum](https://www.alfredforum.com) community.
 
 <a name="changelog"></a>
 # Changelog
@@ -93,5 +83,5 @@ src="https://img.shields.io/github/downloads/giovannicoppola/alfred-almanac/tota
 <a name="feedback"></a>
 # Feedback
 
-Feedback welcome! If you notice a bug, or have ideas for new features, please feel free to get in touch either here, or on the [Alfred](https://www.alfredforum.com) forum. 
+Feedback welcome! If you notice a bug, or have ideas for new features, please feel free to get in touch either here, or on the [Alfred](https://www.alfredforum.com) forum.
 

--- a/source/info.plist
+++ b/source/info.plist
@@ -4,8 +4,8 @@
 <dict>
 	<key>bundleid</key>
 	<string>giovanni-almanac</string>
-	<key>category</key>
-	<string>Productivity</string>
+        <key>category</key>
+        <string>Productivity</string>
 	<key>connections</key>
 	<dict>
 		<key>3B9C56F6-92CA-4E97-92EF-20C22F571619</key>
@@ -157,7 +157,7 @@
 				<key>escaping</key>
 				<integer>102</integer>
 				<key>keyword</key>
-				<string>!w</string>
+				<string>{var:mainkeyword}</string>
 				<key>queuedelaycustom</key>
 				<integer>3</integer>
 				<key>queuedelayimmediatelyinitially</key>
@@ -276,16 +276,16 @@ python3 almanac.py $1 "${LOCATION}"</string>
 		</dict>
 	</array>
 	<key>readme</key>
-	<string>- Launch `alfred-almanac` to retrieve weather and other almanac information from default locations ... 
+	<string>- Launch `alfred-almanac` to retrieve weather and other almanac information from default locations ...
 - ... or enter a location/ZIP code directly
 - The default weather string will output:
 	- `%C` weather condition text
-	- `%c` weather condition 
+	- `%c` weather condition
 	- 🌡️`%t` actual temperature
 	- `%f`  'feels like' temperature
 	- `%h` humidity
 	- 🌬️`%w` wind
-	- `%m` moon phase	
+	- `%m` moon phase
 - The almanac section will output:
 	- local date and time
 	- Current week of the year
@@ -294,7 +294,7 @@ python3 almanac.py $1 "${LOCATION}"</string>
 	- days from and to the special day
 
 - Enter (↩️) will copy to the clipboard and past to the frontmost application
-- Shift-enter (⇧↩️) will open the corresponding page on `wttr.in` 
+- Shift-enter (⇧↩️) will open the corresponding page on `wttr.in`
 - CTRL-enter (⌃↩️) will show the almanac string in large font</string>
 	<key>uidata</key>
 	<dict>
@@ -350,6 +350,27 @@ python3 almanac.py $1 "${LOCATION}"</string>
 	</dict>
 	<key>userconfigurationconfig</key>
 	<array>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>default</key>
+				<string>!w</string>
+				<key>placeholder</key>
+				<string></string>
+				<key>required</key>
+				<false/>
+				<key>trim</key>
+				<true/>
+			</dict>
+			<key>description</key>
+			<string></string>
+			<key>label</key>
+			<string>Keyword</string>
+			<key>type</key>
+			<string>textfield</string>
+			<key>variable</key>
+			<string>mainkeyword</string>
+		</dict>
 		<dict>
 			<key>config</key>
 			<dict>


### PR DESCRIPTION
You mention it in the instruction, so this is how to make a configurable keyword.

<img width="861" alt="image" src="https://user-images.githubusercontent.com/1699443/193105645-65353c59-9615-401b-97c8-8b8d75864baa.png">
<img width="1212" alt="image" src="https://user-images.githubusercontent.com/1699443/193105579-c1a9ef8e-8f37-4238-b02f-093ebc727abb.png">
<img width="174" alt="image" src="https://user-images.githubusercontent.com/1699443/193105609-7d374f81-c880-491f-802c-0070a2b79e2e.png">

Also updated the README’s setup because it taught the old method.